### PR TITLE
Potential fix for code scanning alert no. 347: Likely overrunning write

### DIFF
--- a/orc-ai/destin/Destin/DavisDestin/src/util.c
+++ b/orc-ai/destin/Destin/DavisDestin/src/util.c
@@ -104,7 +104,7 @@ Destin * CreateDestin( char *filename ) {
     //TODO: fix test config file
     // applies boltzman distibution
     // 0 = off, 1 = on
-    char bts[80]; //belief transform string
+    char bts[81]; //belief transform string
 
     fscanfResult = fscanf(configFile, "%80s", bts);
 


### PR DESCRIPTION
Potential fix for [https://github.com/OzCog/opencog-central/security/code-scanning/347](https://github.com/OzCog/opencog-central/security/code-scanning/347)

To fix the issue, the size of the `bts` buffer should be increased to 81 bytes to accommodate the null terminator. Additionally, the format specifier in the `fscanf` call should remain `%80s` to ensure that at most 80 characters are read, leaving space for the null terminator. This approach ensures that the buffer is not overrun while maintaining the intended functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
